### PR TITLE
.gitattributes file added

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto
+
+/.github export-ignore
+/docs export-ignore
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/phpunit.xml.dist export-ignore
+/README.md export-ignore


### PR DESCRIPTION
With this tiny file, listed files and folders are ignored when requiring the bundle using `--prefer-dis`.
This means that the documentation, the tests and all other non-essential files are not cloned in production with the following benefits:
* lightweight package,
* potentially unsecured files/class used for tests are not available.

See [this nice blog post](https://medium.com/@pavlakis/sharing-with-composer-and-gitattributes-4423f5c4967f) for additional explaination.
As mentioned in this article, you can see what will really be coned in production by executing `git archive -o my-branch.zip HEAD`.
The result is a 13.6ko here with that file and 322ko without it. It may be useless in regards to the size of the bundle, but has significant impact as projects growth and number of daily download increase.

*Side note: even if the LICENCE file is not essential, I usually keep it in production*