### PR TITLE
[refactor] ☕ Short and simple method names

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,16 @@ class FooController
         
         $airtableClient->findBy('tableName', 'fieldName', 'value', Foo::class);      
           
-        $record = $airtableClient->findOneById('tableName', 'id');
+        $record = $airtableClient->find('tableName', 'id');
         
         /** @var Foo $foo */
         $foo = $record->getFields();
             
         echo $foo->bar;
         
-        $airtableClient->findTheLatest('tableName', 'fieldName');
+        $airtableClient->findLast('tableName', 'fieldName');
 
-        $airtableClient->addOneRecord(
+        $airtableClient->add(
             'tableName',
             [
                 'id' => 1,

--- a/src/AirtableClient.php
+++ b/src/AirtableClient.php
@@ -50,7 +50,7 @@ final class AirtableClient implements AirtableClientInterface
     /**
      * {@inheritdoc}
      */
-    public function findOneById(string $table, string $id, ?string $dataClass = null): ?AirtableRecord
+    public function find(string $table, string $id, ?string $dataClass = null): ?AirtableRecord
     {
         $url = sprintf('%s/%s', $table, $id);
         $response = $this->airtableTransport->request('GET', $url);
@@ -65,7 +65,7 @@ final class AirtableClient implements AirtableClientInterface
     /**
      * {@inheritdoc}
      */
-    public function findTheLatest(string $table, $field, ?string $dataClass = null): ?AirtableRecord
+    public function findLast(string $table, $field, ?string $dataClass = null): ?AirtableRecord
     {
         $params = [
             'pageSize' => 1,
@@ -97,7 +97,7 @@ final class AirtableClient implements AirtableClientInterface
     /**
      * {@inheritdoc}
      */
-    public function addOneRecord(string $table, array $fields, ?string $dataClass = null): ?AirtableRecord
+    public function add(string $table, array $fields, ?string $dataClass = null): ?AirtableRecord
     {
         $url = sprintf(
             '%s',

--- a/src/AirtableClientInterface.php
+++ b/src/AirtableClientInterface.php
@@ -36,7 +36,7 @@ interface AirtableClientInterface
      * @param string      $id        Id
      * @param string|null $dataClass The name of the class which will hold fields data
      */
-    public function findOneById(string $table, string $id, ?string $dataClass = null): ?AirtableRecord;
+    public function find(string $table, string $id, ?string $dataClass = null): ?AirtableRecord;
 
     /**
      * Field allowing filtering.
@@ -45,7 +45,7 @@ interface AirtableClientInterface
      * @param mixed       $field
      * @param string|null $dataClass The name of the class which will hold fields data
      */
-    public function findTheLatest(string $table, $field, ?string $dataClass = null): ?AirtableRecord;
+    public function findLast(string $table, $field, ?string $dataClass = null): ?AirtableRecord;
 
     /**
      * Create new record and return the new record of a table.
@@ -54,5 +54,5 @@ interface AirtableClientInterface
      * @param array       $fields    Table fields
      * @param string|null $dataClass The name of the class which will hold fields data
      */
-    public function addOneRecord(string $table, array $fields, ?string $dataClass = null): ?AirtableRecord;
+    public function add(string $table, array $fields, ?string $dataClass = null): ?AirtableRecord;
 }

--- a/tests/Unit/AirtableClientTest.php
+++ b/tests/Unit/AirtableClientTest.php
@@ -143,8 +143,8 @@ class AirtableClientTest extends TestCase
         // Given we have an airtable client
         $airtableClient = $this->getAirtableClient($httpClient);
 
-        // When we call findTheLatest with a data class
-        $results = $airtableClient->findTheLatest('MOCK_TABLE', 'MOCK_FIELD', Customer::class);
+        // When we call findLast with a data class
+        $results = $airtableClient->findLast('MOCK_TABLE', 'MOCK_FIELD', Customer::class);
 
         static::assertNull($results);
     }
@@ -161,8 +161,8 @@ class AirtableClientTest extends TestCase
         // Given we have an airtable client
         $airtableClient = $this->getAirtableClient($httpClient);
 
-        // When we call findTheLatest with a data class
-        $record = $airtableClient->findTheLatest('MOCK_TABLE', 'MOCK_FIELD', Customer::class);
+        // When we call findLast with a data class
+        $record = $airtableClient->findLast('MOCK_TABLE', 'MOCK_FIELD', Customer::class);
 
         // Then the result should be a single AirtableRecord
         static::assertInstanceOf(AirtableRecord::class, $record);
@@ -177,7 +177,7 @@ class AirtableClientTest extends TestCase
     }
 
     /** @test */
-    public function findOneByIdWillReturnObjectIfDataClassIsSet(): void
+    public function findWillReturnObjectIfDataClassIsSet(): void
     {
         // Setup the dummy HttpClient
         $httpClient = $this->createAirtableTransportMock(
@@ -188,8 +188,8 @@ class AirtableClientTest extends TestCase
         // Given we have an airtable client
         $airtableClient = $this->getAirtableClient($httpClient);
 
-        // When we call findOneById with a data class
-        $record = $airtableClient->findOneById('MOCK_TABLE', 'MOCK_ID', Customer::class);
+        // When we call find with a data class
+        $record = $airtableClient->find('MOCK_TABLE', 'MOCK_ID', Customer::class);
 
         $this->assertRecordIdandCreatedTime($record);
         // Then the result should be an AirtableRecord
@@ -204,7 +204,7 @@ class AirtableClientTest extends TestCase
     }
 
     /** @test */
-    public function addOneRecordWillReturnNull()
+    public function addWillReturnNull()
     {
         // Setup the dummy HttpClient
         $httpClient = $this->createAirtableTransportMock(
@@ -216,14 +216,14 @@ class AirtableClientTest extends TestCase
         // Given we have an airtable client
         $airtableClient = $this->getAirtableClient($httpClient);
 
-        // When we call addOneRecord with a data class
-        $record = $airtableClient->addOneRecord('MOCK_TABLE', [], Customer::class);
+        // When we call add with a data class
+        $record = $airtableClient->add('MOCK_TABLE', [], Customer::class);
 
         static::assertNull($record);
     }
 
     /** @test */
-    public function addOneRecordWillReturnObjectIfDataClassIsSet()
+    public function addWillReturnObjectIfDataClassIsSet()
     {
         // Setup the dummy AirtableTransport
         $httpClient = $this->createAirtableTransportMock(
@@ -235,8 +235,8 @@ class AirtableClientTest extends TestCase
         // Given we have an airtable client
         $airtableClient = $this->getAirtableClient($httpClient);
 
-        // When we call addOneRecord with a data class
-        $record = $airtableClient->addOneRecord('MOCK_TABLE', ['id' => 'MOCK_ID']);
+        // When we call add with a data class
+        $record = $airtableClient->add('MOCK_TABLE', ['id' => 'MOCK_ID']);
         $this->assertRecordIdandCreatedTime($record);
         // Then the result should be an AirtableRecord
         static::assertInstanceOf(AirtableRecord::class, $record);


### PR DESCRIPTION
[refactor] ☕ Short and simple method names
-------------------------------------------

## 🍬 1. Renamed `findTheLatest()` to `findLast()`

🔥 Affected files:
- 📝 README (line 72)
- 📂 src/AirtableClient (line 80)
- 📂 src/AirtableClientInterface (line 48)
- ✅ tests/AirtableClientTest (lines 211-248)

## 🍩 2. Renamed `addOneRecord()` to `add()`

🔥 Affected files:
- 📝 README (line 74)
- 📂 src/AirtableClient (line 113)
- 📂 src/AirtableClientInterface (line 57)
- ✅ tests/AirtableClientTest (lines 312-363)

## 🍰 3. Renamed `findOneById()` to `find()`

🔥 Affected files:
- 📝 README (line 65)
- 📂 src/AirtableClient (line 65)
- 📂 src/AirtableClientInterface (line 39)
- ✅ tests/AirtableClientTest (lines 267-293)
