### PR TITLE
fix: add Bearer in Headers Authorization

### DIFF
--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -14,7 +14,7 @@ return static function (ContainerConfigurator $container): void {
     $scopeConfig = [
         'base_uri' => AirtableTransport::BASE_URI,
         'headers' => [
-            'Authorization' => param('yoanbernabeu_airtable_client.airtable_client.key'),
+            'Authorization' => 'Bearer '.param('yoanbernabeu_airtable_client.airtable_client.key'),
             'Accept' => 'application/json',
         ],
     ];

--- a/tests/Functional/AirtableTransportTest.php
+++ b/tests/Functional/AirtableTransportTest.php
@@ -28,7 +28,7 @@ class AirtableTransportTest extends KernelTestCase
         $configuredOptions = $response->getRequestOptions();
 
         static::assertEquals([
-            'Authorization: dummy key',
+            'Authorization: Bearer dummy key',
             'Accept: application/json',
         ], $configuredOptions['headers'], 'Inspect headers is well configured');
 


### PR DESCRIPTION
Small fix, to add the mention of "Bearer" in the Authorization Header.