### PR TITLE
Easy form creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ To find your **Airtable API key**, go to your **Account options** and search in 
 
 ## Usage
 
+### Find
+
 ```php
 
 use Yoanbernabeu\AirtableClientBundle\AirtableClientInterface;
@@ -76,9 +78,70 @@ class FooController
             [
                 'id' => 1,
                 'bar' => 'lorem ipsum',
-                ClassTest::class
+                Foo::class
             ]
         );
+    }
+
+    // ...
+}
+```
+
+### Add
+
+```php
+
+use Yoanbernabeu\AirtableClientBundle\AirtableClientInterface;
+
+class Foo
+{
+    public int $id;
+    public string $bar;
+}
+
+class FooController
+{
+    public function bar(AirtableClientInterface $airtableClient)
+    {
+        $airtableClient->addOneRecord(
+            'tableName',
+            [
+                'id' => 1,
+                'bar' => 'lorem ipsum',
+                Foo::class
+            ]
+        );
+    }
+
+    // ...
+}
+```
+
+### Create Form
+
+```php
+
+use Yoanbernabeu\AirtableClientBundle\AirtableClientInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class FooController
+{
+    public function bar(AirtableClientInterface $airtableClient, Request $request)
+    {
+        $form = $airtableClient->createForm([
+            'Name' => TextType::class,
+            'text' => TextType::class,
+            'Submit' => SubmitType::class
+        ]);
+
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
+            $data = $form->getData();
+            $airtableClient->addOneRecord('test', $data);
+        }
+        return $this->render('bar.html.twig', [
+            'form' => $form->createView()
+        ]);
     }
 
     // ...

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ class FooController
 {
     public function bar(AirtableClientInterface $airtableClient)
     {
-        $airtableClient->addOneRecord(
+        $airtableClient->add(
             'tableName',
             [
                 'id' => 1,
@@ -137,7 +137,7 @@ class FooController
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
-            $airtableClient->addOneRecord('test', $data);
+            $airtableClient->add('test', $data);
         }
         return $this->render('bar.html.twig', [
             'form' => $form->createView()

--- a/README.md
+++ b/README.md
@@ -64,16 +64,16 @@ class FooController
         
         $airtableClient->findBy('tableName', 'fieldName', 'value', Foo::class);      
           
-        $record = $airtableClient->findOneById('tableName', 'id');
+        $record = $airtableClient->find('tableName', 'id');
         
         /** @var Foo $foo */
         $foo = $record->getFields();
             
         echo $foo->bar;
         
-        $airtableClient->findTheLatest('tableName', 'fieldName');
+        $airtableClient->findLast('tableName', 'fieldName');
 
-        $airtableClient->addOneRecord(
+        $airtableClient->add(
             'tableName',
             [
                 'id' => 1,

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "symfony/dependency-injection": "^5.0",
     "symfony/http-kernel": "^5.0",
     "symfony/serializer": "^5.0",
-    "symfony/property-access": "^5.0"
+    "symfony/property-access": "^5.0",
+    "symfony/form": "^5.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
     "symfony/dependency-injection": "^5.0",
     "symfony/http-kernel": "^5.0",
     "symfony/serializer": "^5.0",
-    "symfony/property-access": "^5.0",
-    "symfony/form": "^5.0"
+    "symfony/property-access": "^5.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/AirtableClient.php
+++ b/src/AirtableClient.php
@@ -53,7 +53,7 @@ final class AirtableClient implements AirtableClientInterface
     /**
      * {@inheritdoc}
      */
-    public function findOneById(string $table, string $id, ?string $dataClass = null): ?AirtableRecord
+    public function find(string $table, string $id, ?string $dataClass = null): ?AirtableRecord
     {
         $url = sprintf('%s/%s', $table, $id);
         $response = $this->airtableTransport->request('GET', $url);
@@ -68,7 +68,7 @@ final class AirtableClient implements AirtableClientInterface
     /**
      * {@inheritdoc}
      */
-    public function findTheLatest(string $table, $field, ?string $dataClass = null): ?AirtableRecord
+    public function findLast(string $table, $field, ?string $dataClass = null): ?AirtableRecord
     {
         $params = [
             'pageSize' => 1,
@@ -100,7 +100,7 @@ final class AirtableClient implements AirtableClientInterface
     /**
      * {@inheritdoc}
      */
-    public function addOneRecord(string $table, array $fields, ?string $dataClass = null): ?AirtableRecord
+    public function add(string $table, array $fields, ?string $dataClass = null): ?AirtableRecord
     {
         $url = sprintf(
             '%s',

--- a/src/AirtableClient.php
+++ b/src/AirtableClient.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Yoanbernabeu\AirtableClientBundle;
 
+use Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationExtension;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\Forms;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 
 final class AirtableClient implements AirtableClientInterface
@@ -121,6 +124,25 @@ final class AirtableClient implements AirtableClientInterface
         $recordData = $this->createRecordFromResponse($dataClass, $recordData);
 
         return AirtableRecord::createFromRecord($recordData);
+    }
+
+    public function createForm(array $fields): FormInterface
+    {
+        $formFactory = Forms::createFormFactoryBuilder()
+            ->addExtension(new HttpFoundationExtension())
+            ->getFormFactory()
+        ;
+
+        $form = $formFactory->createBuilder();
+
+        $i = 0;
+
+        foreach ($fields as $field) {
+            $form->add(array_keys($fields)[$i], $field);
+            ++$i;
+        }
+
+        return $form->getForm();
     }
 
     /**

--- a/src/AirtableClient.php
+++ b/src/AirtableClient.php
@@ -128,10 +128,6 @@ final class AirtableClient implements AirtableClientInterface
 
     public function createForm(array $fields): FormInterface
     {
-        if (!class_exists(Forms::class)) {
-            throw new \Exception('The AirtableClient::createForm method needs the Symfony Form Component to be installed, please add it with Composer : composer req form');
-        }
-
         $form = Forms::createFormFactoryBuilder()
             ->addExtension(new HttpFoundationExtension())
             ->getFormFactory()

--- a/src/AirtableClient.php
+++ b/src/AirtableClient.php
@@ -128,18 +128,14 @@ final class AirtableClient implements AirtableClientInterface
 
     public function createForm(array $fields): FormInterface
     {
-        $formFactory = Forms::createFormFactoryBuilder()
+        $form = Forms::createFormFactoryBuilder()
             ->addExtension(new HttpFoundationExtension())
             ->getFormFactory()
+            ->createBuilder()
         ;
 
-        $form = $formFactory->createBuilder();
-
-        $i = 0;
-
-        foreach ($fields as $field) {
-            $form->add(array_keys($fields)[$i], $field);
-            ++$i;
+        foreach ($fields as $fieldName => $fieldType) {
+            $form->add($fieldName, $fieldType);
         }
 
         return $form->getForm();

--- a/src/AirtableClient.php
+++ b/src/AirtableClient.php
@@ -128,6 +128,10 @@ final class AirtableClient implements AirtableClientInterface
 
     public function createForm(array $fields): FormInterface
     {
+        if (!class_exists(Forms::class)) {
+            throw new \Exception('The AirtableClient::createForm method needs the Symfony Form Component to be installed, please add it with Composer : composer req form');
+        }
+
         $form = Forms::createFormFactoryBuilder()
             ->addExtension(new HttpFoundationExtension())
             ->getFormFactory()

--- a/src/AirtableClientInterface.php
+++ b/src/AirtableClientInterface.php
@@ -39,7 +39,7 @@ interface AirtableClientInterface
      * @param string      $id        Id
      * @param string|null $dataClass The name of the class which will hold fields data
      */
-    public function findOneById(string $table, string $id, ?string $dataClass = null): ?AirtableRecord;
+    public function find(string $table, string $id, ?string $dataClass = null): ?AirtableRecord;
 
     /**
      * Field allowing filtering.
@@ -48,7 +48,7 @@ interface AirtableClientInterface
      * @param mixed       $field
      * @param string|null $dataClass The name of the class which will hold fields data
      */
-    public function findTheLatest(string $table, $field, ?string $dataClass = null): ?AirtableRecord;
+    public function findLast(string $table, $field, ?string $dataClass = null): ?AirtableRecord;
 
     /**
      * Create new record and return the new record of a table.
@@ -57,7 +57,7 @@ interface AirtableClientInterface
      * @param array       $fields    Table fields
      * @param string|null $dataClass The name of the class which will hold fields data
      */
-    public function addOneRecord(string $table, array $fields, ?string $dataClass = null): ?AirtableRecord;
+    public function add(string $table, array $fields, ?string $dataClass = null): ?AirtableRecord;
 
     /**
      * Create form from an array of fields.

--- a/src/AirtableClientInterface.php
+++ b/src/AirtableClientInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Yoanbernabeu\AirtableClientBundle;
 
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormInterface;
+
 interface AirtableClientInterface
 {
     /**
@@ -55,4 +58,11 @@ interface AirtableClientInterface
      * @param string|null $dataClass The name of the class which will hold fields data
      */
     public function addOneRecord(string $table, array $fields, ?string $dataClass = null): ?AirtableRecord;
+
+    /**
+     * Create form from an array of fields.
+     *
+     * @param array $fields Fields of Form
+     */
+    public function createForm(array $fields): FormInterface;
 }

--- a/tests/Unit/AirtableClientTest.php
+++ b/tests/Unit/AirtableClientTest.php
@@ -143,8 +143,8 @@ class AirtableClientTest extends TestCase
         // Given we have an airtable client
         $airtableClient = $this->getAirtableClient($httpClient);
 
-        // When we call findTheLatest with a data class
-        $results = $airtableClient->findTheLatest('MOCK_TABLE', 'MOCK_FIELD', Customer::class);
+        // When we call findLast with a data class
+        $results = $airtableClient->findLast('MOCK_TABLE', 'MOCK_FIELD', Customer::class);
 
         static::assertNull($results);
     }
@@ -161,8 +161,8 @@ class AirtableClientTest extends TestCase
         // Given we have an airtable client
         $airtableClient = $this->getAirtableClient($httpClient);
 
-        // When we call findTheLatest with a data class
-        $record = $airtableClient->findTheLatest('MOCK_TABLE', 'MOCK_FIELD', Customer::class);
+        // When we call findLast with a data class
+        $record = $airtableClient->findLast('MOCK_TABLE', 'MOCK_FIELD', Customer::class);
 
         // Then the result should be a single AirtableRecord
         static::assertInstanceOf(AirtableRecord::class, $record);
@@ -177,7 +177,7 @@ class AirtableClientTest extends TestCase
     }
 
     /** @test */
-    public function findOneByIdWillReturnObjectIfDataClassIsSet(): void
+    public function findWillReturnObjectIfDataClassIsSet(): void
     {
         // Setup the dummy HttpClient
         $httpClient = $this->createAirtableTransportMock(
@@ -188,8 +188,8 @@ class AirtableClientTest extends TestCase
         // Given we have an airtable client
         $airtableClient = $this->getAirtableClient($httpClient);
 
-        // When we call findOneById with a data class
-        $record = $airtableClient->findOneById('MOCK_TABLE', 'MOCK_ID', Customer::class);
+        // When we call find with a data class
+        $record = $airtableClient->find('MOCK_TABLE', 'MOCK_ID', Customer::class);
 
         $this->assertRecordIdandCreatedTime($record);
         // Then the result should be an AirtableRecord
@@ -204,7 +204,7 @@ class AirtableClientTest extends TestCase
     }
 
     /** @test */
-    public function addOneRecordWillReturnNull()
+    public function addWillReturnNull()
     {
         // Setup the dummy HttpClient
         $httpClient = $this->createAirtableTransportMock(
@@ -216,14 +216,14 @@ class AirtableClientTest extends TestCase
         // Given we have an airtable client
         $airtableClient = $this->getAirtableClient($httpClient);
 
-        // When we call addOneRecord with a data class
-        $record = $airtableClient->addOneRecord('MOCK_TABLE', [], Customer::class);
+        // When we call add with a data class
+        $record = $airtableClient->add('MOCK_TABLE', [], Customer::class);
 
         static::assertNull($record);
     }
 
     /** @test */
-    public function addOneRecordWillReturnObjectIfDataClassIsSet()
+    public function addWillReturnObjectIfDataClassIsSet()
     {
         // Setup the dummy AirtableTransport
         $httpClient = $this->createAirtableTransportMock(
@@ -235,8 +235,8 @@ class AirtableClientTest extends TestCase
         // Given we have an airtable client
         $airtableClient = $this->getAirtableClient($httpClient);
 
-        // When we call addOneRecord with a data class
-        $record = $airtableClient->addOneRecord('MOCK_TABLE', ['id' => 'MOCK_ID']);
+        // When we call add with a data class
+        $record = $airtableClient->add('MOCK_TABLE', ['id' => 'MOCK_ID']);
         $this->assertRecordIdandCreatedTime($record);
         // Then the result should be an AirtableRecord
         static::assertInstanceOf(AirtableRecord::class, $record);


### PR DESCRIPTION
I propose to add the possibility of using the Form Component of Symfony to facilitate the creation of an Airtable recording.

An example of use within a Symfony application:

```php
     /**
     * @Route("/add", name="add")
     */
    public function add(AirtableClientInterface $airtableClient, Request $request): Response
    {
        $form = $airtableClient->createForm([
            'Name' => TextType::class,
            'text' => TextType::class,
            'Submit' => SubmitType::class
        ]);

        $form->handleRequest($request);
        if ($form->isSubmitted() && $form->isValid()) {
            $task = $form->getData();
            $airtableClient->add('test', $task);
            return $this->redirectToRoute('home');
        }

        return $this->render('test.html.twig', [
            'form' => $form->createView()
        ]);
    }
```