### PR TITLE
feat : add pagination for findAll

### DIFF
--- a/src/AirtableClientInterface.php
+++ b/src/AirtableClientInterface.php
@@ -21,6 +21,14 @@ interface AirtableClientInterface
     public function findAll(string $table, ?string $view = null, ?string $dataClass = null): array;
 
     /**
+     * Returns a set of rows from AirTable.
+     *
+     * @param string $url      Url to get data
+     * @param array  $response Array response from Airtable
+     */
+    public function pagination(string $url, array $response): array;
+
+    /**
      * Allows you to filter on a field in the table.
      *
      * @param string      $table     Table name


### PR DESCRIPTION
AirTable limits the number of records to 100 per request.
Small modification, to retrieve all the records, using the offset provided by AirTable.
Don't have to create a Breaking Change (and I need the feature for a current pro project)

Thanks for your code review :)