### PR TITLE
FIX: Deprecated: Optional parameter $dataClass declared

### DIFF
--- a/src/AirtableClient.php
+++ b/src/AirtableClient.php
@@ -211,7 +211,7 @@ final class AirtableClient implements AirtableClientInterface
      *
      * @return array An AirtableRecord object
      */
-    private function createRecordFromResponse(?string $dataClass = null, array $recordData)
+    private function createRecordFromResponse(?string $dataClass, array $recordData)
     {
         if (null !== $dataClass) {
             $recordData['fields'] = $this->normalizer->denormalize($recordData['fields'], $dataClass);


### PR DESCRIPTION
Deprecated: Optional parameter $dataClass declared before required parameter $recordData is implicitly treated as a required parameter.

It's a private function, it is never called without parameter so just remove = null should be enough