### PR TITLE
Replace ObjectNormalizer by NormalizerInterface

### DIFF
--- a/src/AirtableClient.php
+++ b/src/AirtableClient.php
@@ -7,19 +7,19 @@ namespace Yoanbernabeu\AirtableClientBundle;
 use Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationExtension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\Forms;
-use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 final class AirtableClient implements AirtableClientInterface
 {
     private AirtableTransportInterface $airtableTransport;
-    private ObjectNormalizer $normalizer;
+    private NormalizerInterface $normalizer;
 
     public function __construct(
         AirtableTransportInterface $airtableTransport,
-        ObjectNormalizer $objectNormalizer
+        NormalizerInterface $normalizer
     ) {
         $this->airtableTransport = $airtableTransport;
-        $this->normalizer = $objectNormalizer;
+        $this->normalizer = $normalizer;
     }
 
     /**


### PR DESCRIPTION
Since symfony/serializer 6.2: The "Symfony\Component\Serializer\Normalizer\ObjectNormalizer" service alias is deprecated, type-hint against "Symfony\Component\Serializer\Normalizer\NormalizerInterface" or implement "Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface" instead. It is being referenced by the "airtable_client" service.